### PR TITLE
Fix lacking space in lualine between "modified" image and number

### DIFF
--- a/.config/nvim/lua/phyvim/core/lualine.lua
+++ b/.config/nvim/lua/phyvim/core/lualine.lua
@@ -99,7 +99,7 @@ function M.setup()
 
   ins_left {
     "diff",
-    symbols = { added = " ", modified = "", removed = " " },
+    symbols = { added = " ", modified = " ", removed = " " },
     diff_color = {
       added = { fg = colors.green },
       modified = { fg = colors.yellow_1 },


### PR DESCRIPTION
Lacking of the space causes image and number overlaps